### PR TITLE
fix 固定ページ、ブログ記事編集画面で、良く使う項目を編集・追加しようとする際のポップアップ内に、リビジョン一覧が表示される

### DIFF
--- a/Event/RevisionControlHelperEventListener.php
+++ b/Event/RevisionControlHelperEventListener.php
@@ -11,7 +11,21 @@ class RevisionControlHelperEventListener extends BcHelperEventListener {
 
 
 	public function formAfterEnd(CakeEvent $event) {
+		if (!BcUtil::isAdminSystem()) {
+			return;
+		}
+
 		$view = $event->subject;
+
+		if (version_compare($view->viewVars['siteConfig']['version'], '4.0.0', '>=')) {
+			if (!in_array($event->data['id'], array('PageAdminEditForm', 'BlogPostForm'))) {
+				return;
+			}
+		} else {
+			if (!in_array($event->data['id'], array('PageForm', 'BlogPostForm'))) {
+				return;
+			}
+		}
 
 		foreach(Configure::read('RevisionControl.views') as $modelName => $requestTarget) {
 			if ($requestTarget['controller'] == $view->request['controller']


### PR DESCRIPTION
フォームのIDで、表示箇所指定を絞ると良いかな？と思いました。
バージョン別で調べてはみたんですが、バージョン別に判定を分けるのか、
設定ファイルかなんかで、バージョンにこだわらずフォームのIDネームで絞るようにするか、
どっちが良いか考えてはみたんですが、結論が出せずでした。
参考程度にでもなれば幸いです。
